### PR TITLE
Link to the SIG interop tools terminology docs

### DIFF
--- a/content/en/resources/_index.md
+++ b/content/en/resources/_index.md
@@ -22,6 +22,9 @@ resources.
 - DORA, SLSA
 - Books and other resources
 
+## Terminology and vocabularies
+
+- [Tools Terminology](./tools-terminology)
 
 ## Industry-specific resources
 

--- a/content/en/resources/tools-terminology/_index.md
+++ b/content/en/resources/tools-terminology/_index.md
@@ -1,0 +1,23 @@
+
+---
+title: "Terminology Used by CI/CD Tools"
+linkTitle: "Tools Terminology"
+weight: 200
+description: >
+  By the SIG Interoperability - a catalog of tools terminology
+layout: docs
+---
+
+# Introduction
+
+There are many ways to greet someone and as humans if we do not understand the word being used we have the ability to observe body language, process tone, and even touch. These many different natural inputs allow us as humans to establish shared vocabulary upon which we have been able to build successful components relevant to our way of living and social norms of interacting.
+
+Unfortunately for machines, this process is not so easy as we humans have to decide if we want to establish norms which we often surface when talking about machine interactions as protocols and best practices or requirements.
+
+Continuous Integration (CI) and Continuous Delivery (CD) practitioners have many tools at their disposal but it is often the case that what we call a pipeline in today’s tool of choice is not called the same thing in the tool we use tomorrow. Again, we can within our sphere of influence and interaction adjust for these nuances but machines talking to one another do not have that same luxury necessarily.
+
+The CDF Interoperability Special Interest Group created a document to collect the basic terms used by CI/CD tools and technologies in order to work on establishing a shared vocabulary for us humans to communicate and collaborate better.
+
+To learn more, read the [tools terminology][tools-terminology] document.
+
+[tools-terminology]: https://github.com/cdfoundation/sig-interoperability/blob/main/docs/tools-terminology.md#terminology-used-by-cicd-tools-and-technologies


### PR DESCRIPTION
We discussed in the SIG interoperability that we would like to make
the tools terminology document more discoverable.

Adding the document introduction and link to the full document in
the learn section of the best practices web-site.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>